### PR TITLE
Add endpoint to fetch soon-to-expire items

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,6 +202,21 @@ def delete_food_item():
     conn.close()
     return jsonify({"result": "success"})
 
+@app.route('/expiring_soon')
+def expiring_soon():
+    conn = mysql.connector.connect(**db_config)
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute("""
+        SELECT name, expiration_date FROM t_inventory
+        WHERE expiration_date IS NOT NULL
+        ORDER BY STR_TO_DATE(expiration_date, '%m/%d') ASC
+        LIMIT 5
+    """)
+    items = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return jsonify(items)
+
     
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
Introduces the /expiring_soon route, which returns up to 5 inventory items with the nearest expiration dates. This helps users quickly identify items that are expiring soon.